### PR TITLE
mars/lnst.cases: Remove ignore on header_rewrite for upstream setup

### DIFF
--- a/mars/lnst.cases
+++ b/mars/lnst.cases
@@ -174,13 +174,6 @@
     </case>
 
     <case>
-        <ignore>
-            <condition>
-                <key> ovs_upstream:(False) </key>
-                <op> == </op>
-                <value> True </value>
-            </condition>
-        </ignore>
         <tags> header_rewrite </tags>
         <name> header_rewrite </name>
         <cmd>


### PR DESCRIPTION
Header rewrite code is now merged in upstream ovs.

Signed-off-by: Roi Dayan <roid@mellanox.com>