### PR TITLE
lnst: Run iperf case in 03-vlan_in_host.py only if ipv is ipv4 or both

### DIFF
--- a/recipes/ovs_offload/03-vlan_in_host.py
+++ b/recipes/ovs_offload/03-vlan_in_host.py
@@ -68,5 +68,5 @@ if ipv in ('ipv6', 'both'):
     g1.run(ping_mod6)
     verify_tc_rules('ipv6')
 
-if do_iperf:
+if do_iperf and ipv in ('ipv4', 'both'):
     tl.iperf(g1_guestnic, h2_vlan10, 10, 'vm1->h2')


### PR DESCRIPTION
Since it runs over ipv4 ip.

Signed-off-by: Roi Dayan <roid@mellanox.com>